### PR TITLE
fixed generateKeyPair() function to return correct privateKey

### DIFF
--- a/src/suffix.js
+++ b/src/suffix.js
@@ -32,7 +32,7 @@
 
             return {
                 public: publicKey.buffer,
-                private: privateKeyBuffer
+                private: privateKey.buffer
             }
         },
         calculateAgreement: function(publicKey, privateKey) {


### PR DESCRIPTION
I think it was just typo error.
